### PR TITLE
Security update url-parse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
                 "identity-obj-proxy": "^3.0.0",
                 "lodash": "^4.17.20",
                 "simplebar": "^5.3.0",
-                "stockfish": "^11.0.0"
+                "stockfish": "^11.0.0",
+                "url-parse": ">=1.5.0"
             },
             "devDependencies": {
                 "@teamsupercell/typings-for-css-modules-loader": "^2.4.0",
@@ -748,7 +749,6 @@
                 "jest-resolve": "^26.6.2",
                 "jest-util": "^26.6.2",
                 "jest-worker": "^26.6.2",
-                "node-notifier": "^8.0.0",
                 "slash": "^3.0.0",
                 "source-map": "^0.6.0",
                 "string-length": "^4.0.1",
@@ -2402,7 +2402,6 @@
             "dependencies": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
-                "fsevents": "~2.3.1",
                 "glob-parent": "~5.1.0",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
@@ -4753,7 +4752,6 @@
             "dependencies": {
                 "@types/favicons": "5.5.0",
                 "find-root": "^1.1.0",
-                "html-webpack-plugin": ">=5.0.0",
                 "parse-author": "^2.0.0",
                 "parse5": "^6.0.1"
             },
@@ -5317,9 +5315,9 @@
             }
         },
         "node_modules/hosted-git-info": {
-            "version": "2.8.8",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-            "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
             "dev": true
         },
         "node_modules/hpack.js": {
@@ -6509,7 +6507,6 @@
                 "@types/node": "*",
                 "anymatch": "^3.0.3",
                 "fb-watchman": "^2.0.0",
-                "fsevents": "^2.1.2",
                 "graceful-fs": "^4.2.4",
                 "jest-regex-util": "^26.0.0",
                 "jest-serializer": "^26.6.2",
@@ -7127,9 +7124,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.20",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
@@ -8451,8 +8448,7 @@
         "node_modules/querystringify": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-            "dev": true
+            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
         },
         "node_modules/randombytes": {
             "version": "2.1.0",
@@ -8847,8 +8843,7 @@
         "node_modules/requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-            "dev": true
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
         },
         "node_modules/reserved-words": {
             "version": "0.1.2",
@@ -10854,10 +10849,9 @@
             }
         },
         "node_modules/url-parse": {
-            "version": "1.4.7",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-            "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
-            "dev": true,
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+            "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
             "dependencies": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
@@ -11310,7 +11304,6 @@
                 "anymatch": "^2.0.0",
                 "async-each": "^1.0.1",
                 "braces": "^2.3.2",
-                "fsevents": "^1.2.7",
                 "glob-parent": "^3.1.0",
                 "inherits": "^2.0.3",
                 "is-binary-path": "^1.0.0",
@@ -16579,9 +16572,9 @@
             "devOptional": true
         },
         "hosted-git-info": {
-            "version": "2.8.8",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-            "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
             "dev": true
         },
         "hpack.js": {
@@ -18047,9 +18040,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.20",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "lodash.debounce": {
             "version": "4.0.8",
@@ -19117,8 +19110,7 @@
         "querystringify": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-            "dev": true
+            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
         },
         "randombytes": {
             "version": "2.1.0",
@@ -19444,8 +19436,7 @@
         "requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-            "dev": true
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
         },
         "reserved-words": {
             "version": "0.1.2",
@@ -21122,10 +21113,9 @@
             }
         },
         "url-parse": {
-            "version": "1.4.7",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-            "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
-            "dev": true,
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+            "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
             "requires": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "webpack-dev-server": "^3.11.2"
     },
     "dependencies": {
+        "url-parse": ">=1.5.0"
         "favicons-webpack-plugin": "^5.0.1",
         "identity-obj-proxy": "^3.0.0",
         "lodash": "^4.17.20",

--- a/package.json
+++ b/package.json
@@ -54,12 +54,12 @@
         "webpack-dev-server": "^3.11.2"
     },
     "dependencies": {
-        "url-parse": ">=1.5.0",
         "favicons-webpack-plugin": "^5.0.1",
         "identity-obj-proxy": "^3.0.0",
         "lodash": "^4.17.20",
         "simplebar": "^5.3.0",
-        "stockfish": "^11.0.0"
+        "stockfish": "^11.0.0",
+        "url-parse": ">=1.5.0"
     },
     "staticFiles": {
         "staticPath": [

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "webpack-dev-server": "^3.11.2"
     },
     "dependencies": {
-        "url-parse": ">=1.5.0"
+        "url-parse": ">=1.5.0",
         "favicons-webpack-plugin": "^5.0.1",
         "identity-obj-proxy": "^3.0.0",
         "lodash": "^4.17.20",


### PR DESCRIPTION
CVE-2021-27515
high severity
Vulnerable versions: < 1.5.0
Patched version: 1.5.0
url-parse before 1.5.0 mishandles certain uses of backslash such as http:/ and interprets the URI as a relative path.